### PR TITLE
prevent docker from trying to pull etheroscope

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     command: "true"
 
   web:
+    build: .
     image: etheroscope
     command: mix do deps.get, phx.server
     links:


### PR DESCRIPTION
# What?
Tell Docker it needs to build the *etheroscope* image as part of the *web service* instead of trying to pull the *etheroscope* image from Docker Hub.

# Why?
Doesn't work otherwise